### PR TITLE
Customize signing level & ignore resources copying

### DIFF
--- a/src/main/kotlin/app/revanced/library/ApkSigner.kt
+++ b/src/main/kotlin/app/revanced/library/ApkSigner.kt
@@ -187,6 +187,7 @@ object ApkSigner {
         privateKeyCertificatePair: PrivateKeyCertificatePair,
         signer: String,
         createdBy: String,
+        sigLevels: Set<Int>,
     ): ApkSigner.Builder {
         logger.fine(
             "Creating new ApkSigner " +
@@ -205,6 +206,9 @@ object ApkSigner {
         // Create the signer.
         return ApkSigner.Builder(listOf(signerConfig)).apply {
             setCreatedBy(createdBy)
+            setV1SigningEnabled(sigLevels.contains(1))
+            setV2SigningEnabled(sigLevels.contains(2))
+            setV3SigningEnabled(sigLevels.contains(3))
         }
     }
 
@@ -228,10 +232,12 @@ object ApkSigner {
         keyStoreEntryPassword: String,
         signer: String,
         createdBy: String,
+        sigLevels: Set<Int>,
     ) = newApkSignerBuilder(
         readKeyCertificatePair(keyStore, keyStoreEntryAlias, keyStoreEntryPassword),
         signer,
         createdBy,
+        sigLevels,
     )
 
     fun ApkSigner.Builder.signApk(

--- a/src/main/kotlin/app/revanced/library/ApkUtils.kt
+++ b/src/main/kotlin/app/revanced/library/ApkUtils.kt
@@ -90,6 +90,7 @@ object ApkUtils {
             signingOptions.password,
             signingOptions.signer,
             signingOptions.signer,
+            signingOptions.sigLevels,
         ).signApk(apk, output)
     }
 
@@ -108,5 +109,6 @@ object ApkUtils {
         val alias: String = "ReVanced Key",
         val password: String = "",
         val signer: String = "ReVanced",
+        val sigLevels: Set<Int>,
     )
 }

--- a/src/main/kotlin/app/revanced/library/ApkUtils.kt
+++ b/src/main/kotlin/app/revanced/library/ApkUtils.kt
@@ -21,11 +21,13 @@ object ApkUtils {
      * @param apkFile The apk to copy entries from.
      * @param outputFile The apk to write the new entries to.
      * @param patchedEntriesSource The result of the patcher to add the patched dex files and resources.
+     * @param ignoreRes not copy resources if true.
      */
     fun copyAligned(
         apkFile: File,
         outputFile: File,
         patchedEntriesSource: PatcherResult,
+        ignoreRes: Boolean,
     ) {
         logger.info("Aligning ${apkFile.name}")
 
@@ -42,16 +44,16 @@ object ApkUtils {
             patchedEntriesSource.resourceFile?.let {
                 file.copyEntriesFromFileAligned(
                     ZipFile(it),
-                    ZipFile.apkZipEntryAlignment,
+                    entryAlignment = ZipFile.apkZipEntryAlignment,
                 )
             }
 
             // TODO: Do not compress result.doNotCompress
 
-            // TODO: Fix copying resources that are not needed anymore.
             file.copyEntriesFromFileAligned(
                 ZipFile(apkFile),
-                ZipFile.apkZipEntryAlignment,
+                ignoreEntryNamePrefixes = if (ignoreRes) listOf("res/", "r/", "R/") else listOf(),
+                entryAlignment = ZipFile.apkZipEntryAlignment,
             )
         }
     }

--- a/src/main/kotlin/app/revanced/library/zip/ZipFile.kt
+++ b/src/main/kotlin/app/revanced/library/zip/ZipFile.kt
@@ -182,14 +182,17 @@ class ZipFile(file: File) : Closeable {
      * Copies all entries from [file] to this file but skip already existing entries.
      *
      * @param file The file to copy entries from.
+     * @param ignoreEntryNamePrefixes entry name prefixes to ignore.
      * @param entryAlignment A function that returns the alignment for a given entry.
      */
     fun copyEntriesFromFileAligned(
         file: ZipFile,
+        ignoreEntryNamePrefixes: List<String> = listOf(),
         entryAlignment: (entry: ZipEntry) -> Int?,
     ) {
         for (entry in file.entries) {
             if (entries.any { it.fileName == entry.fileName }) continue // Skip duplicates
+            if (ignoreEntryNamePrefixes.any { entry.fileName.startsWith(it) }) continue
 
             val data = file.getDataForEntry(entry)
             addEntryCopyData(entry, data, entryAlignment(entry))


### PR DESCRIPTION
The signature verification of some apps (eg. [bilibili](https://dl.hdslb.com/mobile/pack/android64/14056308/iBiliPlayer-apinkRelease-7.66.0-b14056308.apk)) can be bypassed by setting different signing levels.