### PR TITLE
chore: add validations to RootInstaller

### DIFF
--- a/api/android/revanced-library.api
+++ b/api/android/revanced-library.api
@@ -94,6 +94,7 @@ public final class app/revanced/library/installation/command/LocalShellCommandRu
 }
 
 public abstract interface class app/revanced/library/installation/command/RunResult {
+	public abstract fun ensureSuccess ()V
 	public abstract fun getError ()Ljava/lang/String;
 	public abstract fun getExitCode ()I
 	public abstract fun getOutput ()Ljava/lang/String;
@@ -101,6 +102,7 @@ public abstract interface class app/revanced/library/installation/command/RunRes
 }
 
 public final class app/revanced/library/installation/command/RunResult$DefaultImpls {
+	public static fun ensureSuccess (Lapp/revanced/library/installation/command/RunResult;)V
 	public static fun waitFor (Lapp/revanced/library/installation/command/RunResult;)V
 }
 

--- a/api/jvm/revanced-library.api
+++ b/api/jvm/revanced-library.api
@@ -70,6 +70,7 @@ public final class app/revanced/library/installation/command/AdbShellCommandRunn
 }
 
 public abstract interface class app/revanced/library/installation/command/RunResult {
+	public abstract fun ensureSuccess ()V
 	public abstract fun getError ()Ljava/lang/String;
 	public abstract fun getExitCode ()I
 	public abstract fun getOutput ()Ljava/lang/String;
@@ -77,6 +78,7 @@ public abstract interface class app/revanced/library/installation/command/RunRes
 }
 
 public final class app/revanced/library/installation/command/RunResult$DefaultImpls {
+	public static fun ensureSuccess (Lapp/revanced/library/installation/command/RunResult;)V
 	public static fun waitFor (Lapp/revanced/library/installation/command/RunResult;)V
 }
 

--- a/src/commonMain/kotlin/app/revanced/library/installation/command/AdbShellCommandRunner.kt
+++ b/src/commonMain/kotlin/app/revanced/library/installation/command/AdbShellCommandRunner.kt
@@ -41,10 +41,14 @@ class AdbShellCommandRunner : ShellCommandRunner {
             override fun waitFor() {
                 process.waitFor()
             }
+
+            override fun ensureSuccess() {
+                if (exitCode != 0) throw ShellCmdFailure()
+            }
         }
     }
 
-    override fun hasRootPermission(): Boolean = invoke("whoami").exitCode == 0
+    override fun hasRootPermission(): Boolean = invoke("exit").exitCode == 0
 
     override fun write(content: InputStream, targetFilePath: String) =
         device.push(content, System.currentTimeMillis(), 644, RemoteFile(targetFilePath))
@@ -56,4 +60,6 @@ class AdbShellCommandRunner : ShellCommandRunner {
      * @param targetFilePath The target file path.
      */
     override fun move(file: File, targetFilePath: String) = device.push(file, RemoteFile(targetFilePath))
+
+    internal class ShellCmdFailure internal constructor() : Exception("Shell command execution failure")
 }

--- a/src/commonMain/kotlin/app/revanced/library/installation/command/RunResult.kt
+++ b/src/commonMain/kotlin/app/revanced/library/installation/command/RunResult.kt
@@ -1,5 +1,7 @@
 package app.revanced.library.installation.command
 
+import app.revanced.library.installation.command.AdbShellCommandRunner.ShellCmdFailure
+
 /**
  * The result of a command execution.
  */
@@ -23,4 +25,11 @@ interface RunResult {
      * Waits for the command to finish.
      */
     fun waitFor() {}
+
+    /**
+     * Verifies whether the command exits with code 0.
+     *
+     * @throws ShellCmdFailure if given [RunResult] exited unsuccessfully.
+     */
+    fun ensureSuccess() {}
 }

--- a/src/commonMain/kotlin/app/revanced/library/installation/installer/AdbInstaller.kt
+++ b/src/commonMain/kotlin/app/revanced/library/installation/installer/AdbInstaller.kt
@@ -2,7 +2,6 @@ package app.revanced.library.installation.installer
 
 import app.revanced.library.installation.command.AdbShellCommandRunner
 import app.revanced.library.installation.installer.Constants.INSTALLED_APK_PATH
-import app.revanced.library.installation.installer.Installer.Apk
 import se.vidstige.jadb.JadbException
 import se.vidstige.jadb.managers.Package
 import se.vidstige.jadb.managers.PackageManager

--- a/src/commonMain/kotlin/app/revanced/library/installation/installer/Installer.kt
+++ b/src/commonMain/kotlin/app/revanced/library/installation/installer/Installer.kt
@@ -1,6 +1,5 @@
 package app.revanced.library.installation.installer
 
-import app.revanced.library.installation.installer.Installer.Apk
 import java.io.File
 import java.util.logging.Logger
 


### PR DESCRIPTION
- add extra sanity check to mount script - bail if package is still mounted after unmount execution
- RootInstaller:
  - install():
    - ensure mount script installation exits w/ 0;
    - ensure mount script execution exits w/ 0;
  - uninstall():
    - bail if package-to-be-unmounted is not mounted; indicates likely error on user part
    - ensure unmount script exits w/ 0;
- related to https://github.com/ReVanced/revanced-cli/issues/362