### PR TITLE
fix: Create dex file streams on-demand

### DIFF
--- a/src/commonMain/kotlin/app/revanced/library/ApkUtils.kt
+++ b/src/commonMain/kotlin/app/revanced/library/ApkUtils.kt
@@ -53,7 +53,7 @@ object ApkUtils {
     fun PatcherResult.applyTo(apkFile: File) {
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->
             dexFiles.forEach { dexFile ->
-                targetApkZFile.add(dexFile.name, dexFile.stream)
+                targetApkZFile.add(dexFile.name, dexFile.file.inputStream())
             }
 
             resources?.let { resources ->


### PR DESCRIPTION
Added in conjunction with https://github.com/ReVanced/revanced-patcher/pull/343

The parent `use()` block will call the finalizer of the input streams when it closes itself.