### PR TITLE
fix: Make ShellCommandRunner run without root

### DIFF
--- a/src/commonMain/kotlin/app/revanced/library/installation/command/AdbShellCommandRunner.kt
+++ b/src/commonMain/kotlin/app/revanced/library/installation/command/AdbShellCommandRunner.kt
@@ -35,7 +35,7 @@ class AdbShellCommandRunner : ShellCommandRunner {
     override fun runCommand(command: String) = device.shellProcessBuilder(command).start().let { process ->
         object : RunResult {
             override val exitCode by lazy { process.waitFor() }
-            override val output by lazy { process.inputStream.bufferedReader().readText() }
+            override val output by lazy { process.inputStream.bufferedReader().readText().removeSuffix("\n") }
             override val error by lazy { process.errorStream.bufferedReader().readText() }
 
             override fun waitFor() {
@@ -44,7 +44,7 @@ class AdbShellCommandRunner : ShellCommandRunner {
         }
     }
 
-    override fun hasRootPermission(): Boolean = invoke("whoami").exitCode == 0
+    override fun hasRootPermission(): Boolean = invoke("su -c whoami").exitCode == 0
 
     override fun write(content: InputStream, targetFilePath: String) =
         device.push(content, System.currentTimeMillis(), 644, RemoteFile(targetFilePath))

--- a/src/commonMain/kotlin/app/revanced/library/installation/command/ShellCommandRunner.kt
+++ b/src/commonMain/kotlin/app/revanced/library/installation/command/ShellCommandRunner.kt
@@ -55,5 +55,5 @@ abstract class ShellCommandRunner internal constructor() {
      */
     internal operator fun invoke(
         command: String,
-    ) = runCommand("su -c \'$command\'")
+    ) = runCommand(command)
 }

--- a/src/commonMain/kotlin/app/revanced/library/installation/installer/RootInstaller.kt
+++ b/src/commonMain/kotlin/app/revanced/library/installation/installer/RootInstaller.kt
@@ -100,7 +100,7 @@ abstract class RootInstaller internal constructor(
     /**
      * Runs a command on the device.
      */
-    protected operator fun String.invoke() = shellCommandRunner(this)
+    protected operator fun String.invoke() = shellCommandRunner("su -c \'$this\'")
 
     /**
      * Moves the given file to the given [targetFilePath].


### PR DESCRIPTION
Currently, every command run by a `ShellCommandRunner` will be run with `su` (root required). With this PR, root will only be required from a `RootInstaller`. 
Also remove latest `\n` from shell output.

Closes https://github.com/ReVanced/revanced-library/issues/72.