### PR TITLE
docs: Make license section use American spelling

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ you can follow the [ReVanced documentation](https://github.com/ReVanced/revanced
 
 ## 📜 License
 
-ReVanced Library is licensed under the GPLv3 license. Please see the [licence file](LICENSE) for more information.
+ReVanced Library is licensed under the GPLv3 license. Please see the [license file](LICENSE) for more information.
 [tl;dr](https://www.tldrlegal.com/license/gnu-general-public-license-v3-gpl-3) you may copy, distribute and modify ReVanced Library as long as you track changes/dates in source files.
 Any modifications to ReVanced Library must also be made available under the GPL,
 along with build & install instructions.


### PR DESCRIPTION
This is on my todolist for a very long time, I'll propagate this PR to other revanced repositories after the PR is merged within N+2 days unless requested change.

The license section uses British spelling of the word license ("licence"), which isn't intentional because ReVanced uses American spelling officially. 

Propagator!