### PR TITLE
fix: Close streams to be able to delete cache folder

### DIFF
--- a/src/commonMain/kotlin/app/revanced/library/ApkUtils.kt
+++ b/src/commonMain/kotlin/app/revanced/library/ApkUtils.kt
@@ -53,7 +53,8 @@ object ApkUtils {
     fun PatcherResult.applyTo(apkFile: File) {
         ZFile.openReadWrite(apkFile, zFileOptions).use { targetApkZFile ->
             dexFiles.forEach { dexFile ->
-                dexFile.stream.use { targetApkZFile.add(dexFile.name, it) }
+                targetApkZFile.add(dexFile.name, dexFile.stream)
+                dexFile.stream.close()
             }
 
             resources?.let { resources ->


### PR DESCRIPTION
Added in conjunction with https://github.com/ReVanced/revanced-patcher/pull/343

The parent `use()` block will call the finalizer of the input streams when it closes itself.

https://github.com/ReVanced/revanced-cli/issues/327